### PR TITLE
Email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 configFile.cfg
 *pyc
 *swp
+*log

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ configFile.cfg
 *pyc
 *swp
 *log
+books
+!books/readme

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+configFile.cfg
+*pyc
+*swp

--- a/configFileTemplate.cfg
+++ b/configFileTemplate.cfg
@@ -11,4 +11,5 @@ logFile: logfile.log
 [MAIL]
 fromEmail: some_email@example.com
 toEmails: email1@example.com, email2@example.com
+bccEmails: bccmail@example.com
 kindleEmails: some_email@kindle.com

--- a/configFileTemplate.cfg
+++ b/configFileTemplate.cfg
@@ -11,5 +11,6 @@ logFile: logfile.log
 [MAIL]
 fromEmail: some_email@example.com
 toEmails: email1@example.com, email2@example.com
-bccEmails: bccmail@example.com
+ccEmails: email3@example.com, email4@example.com
+bccEmails: email5@example.com, email6@example.com
 kindleEmails: some_email@kindle.com

--- a/configFileTemplate.cfg
+++ b/configFileTemplate.cfg
@@ -9,6 +9,6 @@ downloadBookTitles: Unity 4.x Game AI Programming , Multithreading in C# 5.0 Coo
 logFile: logfile.log
 
 [MAIL]
-fromEmail: blabla@bobbelderbos.com
-toEmails: bob@gmail.com, jul@gmail.com
+fromEmail: some_email@example.com
+toEmails: email1@example.com, email2@example.com
 kindleEmails: some_email@kindle.com

--- a/configFileTemplate.cfg
+++ b/configFileTemplate.cfg
@@ -7,3 +7,8 @@ downloadFolderPath: C:\Users\me\Desktop\myEbooksFromPackt
 downloadFormats: pdf, epub, mobi, code
 downloadBookTitles: Unity 4.x Game AI Programming , Multithreading in C# 5.0 Cookbook 
 logFile: logfile.log
+
+[MAIL]
+fromEmail: blabla@bobbelderbos.com
+toEmails: bob@gmail.com, jul@gmail.com
+kindleEmails: some_email@kindle.com

--- a/mailBook.py
+++ b/mailBook.py
@@ -10,7 +10,7 @@ from email.utils import COMMASPACE, formatdate
 COMMA = ", "
 CONFIG_FILE = "configFile.cfg"
 DEFAULT_BODY = "Enjoy!"
-SERVER = "127.0.0.1"
+SERVER = "localhost"
 DEFAULT_SUBJECT = "New free packt ebook"
 
 class MailBook:

--- a/mailBook.py
+++ b/mailBook.py
@@ -9,7 +9,7 @@ from email.utils import COMMASPACE, formatdate
 
 COMMA = ", "
 CONFIG_FILE = "configFile.cfg"
-DEFAULT_MSG = "Enjoy!"
+DEFAULT_BODY = "Enjoy!"
 SERVER = "127.0.0.1"
 DEFAULT_SUBJECT = "New free packt ebook"
 
@@ -27,7 +27,7 @@ class MailBook:
             raise ValueError("ERROR: need at least one from and one or more to emails")
         self.kindle_emails = config.get("MAIL", 'kindleEmails').split(COMMA)
 
-    def send_book(self, book, to=None, subject=None, msg=None):
+    def send_book(self, book, to=None, subject=None, body=None):
         if not os.path.isfile(book):
             raise
         book_name = basename(book)
@@ -38,8 +38,8 @@ class MailBook:
         msg['To'] = COMMASPACE.join(self.to_emails)
         msg['Date'] = formatdate(localtime=True)
         msg['Subject'] = subject if subject else "{}: {}".format(DEFAULT_SUBJECT, book_name)
-        msg = msg if msg else DEFAULT_MSG
-        msg.attach(MIMEText(msg))
+        body = body if body else DEFAULT_BODY
+        msg.attach(MIMEText(body))
         with open(book, "rb") as f:
             part = MIMEApplication(
                 f.read(),
@@ -59,5 +59,6 @@ class MailBook:
 
 if __name__ == "__main__":
     mb = MailBook()
-    mb.send_kindle("/home3/bobbelde/code/third-party/packt/books/Learning NGUI for Unity.mobi")
+    mb.send_kindle("/Users/bbelderb/Dropbox/books/programming books/Head_First_Design_Patterns.mobi")
+    #mb.send_kindle("/home3/bobbelde/code/third-party/packt/books/Learning NGUI for Unity.mobi")
     #mb.send_mail("abc@bobcodes.it", ["hello@gmail.com"], "test", "your new free ebook for today", files=["books/somebooks.pdf"])

--- a/mailBook.py
+++ b/mailBook.py
@@ -1,0 +1,63 @@
+import configparser
+import os
+import smtplib
+from os.path import basename
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import COMMASPACE, formatdate
+
+COMMA = ", "
+CONFIG_FILE = "configFile.cfg"
+DEFAULT_MSG = "Enjoy!"
+SERVER = "127.0.0.1"
+DEFAULT_SUBJECT = "New free packt ebook"
+
+class MailBook:
+
+    def __init__(self):
+        cfgFilePath = os.path.join(os.getcwd(), CONFIG_FILE)
+        myDefaults = {'fromEmail': None,'toEmails': [],'kindleEmails': None, }
+        config = configparser.ConfigParser(defaults=myDefaults)
+        config.read(cfgFilePath)
+        try:
+            self.send_from = config.get("MAIL", 'fromEmail')
+            self.to_emails = config.get("MAIL", 'toEmails').split(COMMA)
+        except configparser.NoSectionError:
+            raise ValueError("ERROR: need at least one from and one or more to emails")
+
+    def send_book(self, book, to=None, subject=None, msg=None):
+        if not os.path.isfile(book):
+            raise
+        book_name = basename(book)
+        msg = MIMEMultipart()
+        msg['From'] = self.send_from
+        if to:
+            self.to_emails = to
+        msg['To'] = COMMASPACE.join(self.to_emails)
+        msg['Date'] = formatdate(localtime=True)
+        msg['Subject'] = subject if subject else "{}: {}".format(DEFAULT_SUBJECT, book_name)
+        msg = msg if msg else DEFAULT_MSG
+        msg.attach(MIMEText(msg))
+        with open(book, "rb") as f:
+            part = MIMEApplication(
+                f.read(),
+                Name=book_name
+            )
+            part['Content-Disposition'] = 'attachment; filename="{}"'.format(book_name)
+            msg.attach(part)
+        smtp = smtplib.SMTP(SERVER)
+        smtp.sendmail(self.send_from, self.to_emails, msg.as_string())
+        smtp.close()
+
+    def send_kindle(self, book):
+        kindle_emails = config.get("MAIL", 'kindleEmails').split(COMMA)
+        if not kindle_emails:
+            return
+        self.send_book(book, to=kindle_emails) 
+
+
+if __name__ == "__main__":
+    mb = MailBook()
+    mb.send_kindle("/home3/bobbelde/code/third-party/packt/books/Learning NGUI for Unity.mobi")
+    #mb.send_mail("abc@bobcodes.it", ["hello@gmail.com"], "test", "your new free ebook for today", files=["books/somebooks.pdf"])

--- a/mailBook.py
+++ b/mailBook.py
@@ -23,6 +23,7 @@ class MailBook:
         try:
             self.send_from = config.get("MAIL", 'fromEmail')
             self.to_emails = config.get("MAIL", 'toEmails').split(COMMA)
+            self.bcc_emails = config.get("MAIL", 'bccEmails').split(COMMA)
         except configparser.NoSectionError:
             raise ValueError("ERROR: need at least one from and one or more to emails")
         self.kindle_emails = config.get("MAIL", 'kindleEmails').split(COMMA)
@@ -48,7 +49,7 @@ class MailBook:
             part['Content-Disposition'] = 'attachment; filename="{}"'.format(book_name)
             msg.attach(part)
         smtp = smtplib.SMTP(SERVER)
-        smtp.sendmail(self.send_from, self.to_emails, msg.as_string())
+        smtp.sendmail(self.send_from, self.to_emails + self.bcc_emails, msg.as_string())
         smtp.close()
 
     def send_kindle(self, book):

--- a/mailBook.py
+++ b/mailBook.py
@@ -25,6 +25,7 @@ class MailBook:
             self.to_emails = config.get("MAIL", 'toEmails').split(COMMA)
         except configparser.NoSectionError:
             raise ValueError("ERROR: need at least one from and one or more to emails")
+        self.kindle_emails = config.get("MAIL", 'kindleEmails').split(COMMA)
 
     def send_book(self, book, to=None, subject=None, msg=None):
         if not os.path.isfile(book):
@@ -51,10 +52,9 @@ class MailBook:
         smtp.close()
 
     def send_kindle(self, book):
-        kindle_emails = config.get("MAIL", 'kindleEmails').split(COMMA)
-        if not kindle_emails:
+        if not self.kindle_emails:
             return
-        self.send_book(book, to=kindle_emails) 
+        self.send_book(book, to=self.kindle_emails) 
 
 
 if __name__ == "__main__":

--- a/mailBook.py
+++ b/mailBook.py
@@ -59,6 +59,4 @@ class MailBook:
 
 if __name__ == "__main__":
     mb = MailBook()
-    mb.send_kindle("/Users/bbelderb/Dropbox/books/programming books/Head_First_Design_Patterns.mobi")
-    #mb.send_kindle("/home3/bobbelde/code/third-party/packt/books/Learning NGUI for Unity.mobi")
-    #mb.send_mail("abc@bobcodes.it", ["hello@gmail.com"], "test", "your new free ebook for today", files=["books/somebooks.pdf"])
+    mb.send_kindle("Learning NGUI for Unity.mobi")

--- a/packtPublishingFreeEbook.py
+++ b/packtPublishingFreeEbook.py
@@ -296,6 +296,8 @@ if __name__ == '__main__':
                         action="store_true")
     parser.add_argument("-dc", "--dchosen", help="downloads chosen titles described in [downloadBookTitles] field",
                         action="store_true")
+    parser.add_argument("-m", "--mail", help="send download to emails defined in config file", default=False,
+                        action="store_true")
     args = parser.parse_args()
     cfgFilePath = os.path.join(os.getcwd(), "configFile.cfg")
     try:
@@ -310,7 +312,7 @@ if __name__ == '__main__':
         if args.grabd or args.dall or args.dchosen:
             downloader.getDataOfAllMyBooks()
         if args.grabd:
-            downloader.downloadBooks([grabber.bookTitle], mail=True)
+            downloader.downloadBooks([grabber.bookTitle], mail=args.mail) # only use email for single title option
         elif args.dall:
             downloader.downloadBooks()
         elif args.dchosen:

--- a/packtPublishingFreeEbook.py
+++ b/packtPublishingFreeEbook.py
@@ -31,7 +31,7 @@ import re
 from collections import OrderedDict
 from bs4 import BeautifulSoup
 
-from mail import send_mail 
+from mailBook import MailBook 
 
 logging.basicConfig(format='[%(levelname)s] - %(message)s', filename='logfile.log', level=logging.INFO)
 # adding a new logging level
@@ -271,10 +271,11 @@ class BookDownloader(object):
                             nrOfBooksDownloaded = i + 1
                             if mail:
                                 logger.info("emailing book {} to mail and kindle".format(fullFilePath))
+                                mb = MailBook()
                                 if form == 'pdf':
-                                    send_mail("info@bobbelderbos.com", ["bobbelderbos@gmail.com", "sequeira.julian@gmail.com"], "new free packt book", "today's free ebook (automate the boring stuff hahaha)", files=[fullFilePath])
-                                if form == 'mobi':
-                                    send_mail("info@bobbelderbos.com", ["bobbelderbos_22@kindle.com"], "new free packt book", "today's free ebook", files=[fullFilePath])
+                                    mb.send_book(fullFilePath)
+                                elif form == 'mobi':
+                                    mb.send_kindle(fullFilePath)
                         else:
                             message = "Cannot download '{}'".format(title)
                             logger.error(message)

--- a/packtPublishingFreeEbook.py
+++ b/packtPublishingFreeEbook.py
@@ -31,8 +31,9 @@ import re
 from collections import OrderedDict
 from bs4 import BeautifulSoup
 
+from mail import send_mail 
 
-logging.basicConfig(format='[%(levelname)s] - %(message)s', level=logging.INFO)
+logging.basicConfig(format='[%(levelname)s] - %(message)s', filename='logfile.log', level=logging.INFO)
 # adding a new logging level
 logging.SUCCESS = 13
 logging.addLevelName(logging.SUCCESS, 'SUCCESS')
@@ -159,7 +160,7 @@ class FreeEBookGrabber(object):
         self.__writeEbookInfoData(resultData)
         return resultData
 
-    def grabEbook(self, log=False):
+    def grabEbook(self, log=True):
         """Grabs the ebook"""
         logger.info("Start grabbing eBook...")
         r = self.session.get(self.accountData.freeLearningUrl,
@@ -215,7 +216,7 @@ class BookDownloader(object):
                         downloadUrls['code'] = m.group(0)
             self.bookData[i]['downloadUrls'] = downloadUrls
 
-    def downloadBooks(self, titles=None, formats=None):
+    def downloadBooks(self, titles=None, formats=None, mail=False):
         """
         Downloads the ebooks.
         :param titles: list('C# tutorial', 'c++ Tutorial') ;
@@ -268,6 +269,12 @@ class BookDownloader(object):
                             else:
                                 logger.success("eBook: '{}.{}' downloaded successfully!".format(title, form))
                             nrOfBooksDownloaded = i + 1
+                            if mail:
+                                logger.info("emailing book {} to mail and kindle".format(fullFilePath))
+                                if form == 'pdf':
+                                    send_mail("info@bobbelderbos.com", ["bobbelderbos@gmail.com", "sequeira.julian@gmail.com"], "new free packt book", "today's free ebook (automate the boring stuff hahaha)", files=[fullFilePath])
+                                if form == 'mobi':
+                                    send_mail("info@bobbelderbos.com", ["bobbelderbos_22@kindle.com"], "new free packt book", "today's free ebook", files=[fullFilePath])
                         else:
                             message = "Cannot download '{}'".format(title)
                             logger.error(message)
@@ -302,7 +309,7 @@ if __name__ == '__main__':
         if args.grabd or args.dall or args.dchosen:
             downloader.getDataOfAllMyBooks()
         if args.grabd:
-            downloader.downloadBooks([grabber.bookTitle])
+            downloader.downloadBooks([grabber.bookTitle], mail=True)
         elif args.dall:
             downloader.downloadBooks()
         elif args.dchosen:


### PR DESCRIPTION
Hi, I created a module for email, it works on my server for regular email, but kindle not. Maybe you can try it ... 

Apart from module, I added:
- extra -m (mail) flag to invoke this
- in config this section

[MAIL]
fromEmail: some_email@example.com
toEmails: email1@example.com, email2@example.com
kindleEmails: some_email@kindle.com 

re Kindle, not sure if it is my config, I also tried https://github.com/MichaelRupertDev/py2kindle independently and while no error, I don't get the book (I added the from email to my Amazon Kindle settings of course). anyways, I think main thing is the mail option, I find a pdf in my inbox every morning, which I find pretty useful.