### PR TITLE
Fix - Fetching info from the actual free book's page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ configFile.cfg
 *.log
 __pycache__/
 *.pyc
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ configFile.cfg
 *.log
 __pycache__/
 *.pyc
+.vscode

--- a/packtPublishingFreeEbook.py
+++ b/packtPublishingFreeEbook.py
@@ -153,7 +153,7 @@ class FreeEBookGrabber(object):
         resultData["author"] = author.text.strip().split("\n")[0]
         resultData["date_published"] = page.find('time').text
         codeDownloadUrl = page.find('div', {'class': 'book-top-block-code'}).find('a').attrs['href']
-        resultData["code_files_url"] = "https://packtpub.com{}".format(codeDownloadUrl)
+        resultData["code_files_url"] = self.accountData.packtPubUrl + codeDownloadUrl
         resultData["downloaded_at"] = time.strftime("%d-%m-%Y %H:%M")
         logger.success("Info data retrieved for '{}'".format(self.bookTitle))
         self.__writeEbookInfoData(resultData)


### PR DESCRIPTION
This issues my concern on #27 , i hope you feel comfortable with the changes I'm proposing as I feel they'll be handy to the end-user.

Proposed:

- Changing the name of the "time" tag to "Date published", also giving them only the Month and year of publishing. I could change it back again to get the datetime attribute.
- Giving the user the URL to directly download current book's code files.
