### PR TITLE
Add dependency configparser

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 beautifulsoup4==4.5.1
 future
 wheel==0.24.0
+configparser


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/user/tools/Packt-Publishing-Free-Learning/packtPublishingFreeEbook.py", line 27, in <module>
    import configparser
ImportError: No module named configparser
```