### PR TITLE
Granting GoogleDrive persmission when user cannot launch local browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ Full info about the Google Drive python API can be found [here](https://develope
   ```
   python packtPublishingFreeEbook.py -sgd
   ```  
+  - Or if you're unable to launch browser locally (e.g. you're connecting through SSH without X11 forwarding) use this command once, follow instructions and give permission and later you can use normal command (without *--noauth_local_webserver*).
+  ```
+  python packtPublishingFreeEbook.py -sgd --noauth_local_webserver
+  ```  
 4. Already done!
   - Run the same command as above to claim and upload the eBook to Google Drive.
 

--- a/src/packtPublishingFreeEbook.py
+++ b/src/packtPublishingFreeEbook.py
@@ -310,6 +310,8 @@ if __name__ == '__main__':
                         action="store_true")
     parser.add_argument("-f", "--folder", help="downloads eBook into a folder", default=False,
                         action="store_true")
+    parser.add_argument("--noauth_local_webserver", help="set if you want auth GoogleDrive without local browser",
+                        action="store_true")
 
     args = parser.parse_args()
     cfgFilePath = os.path.join(os.getcwd(), "configFile.cfg")


### PR DESCRIPTION
In case user is not running the script locally, google-api-python-client allows to give permission with different flow (without need to launch browser locally)
In this case flow will look like this:

- Run script with --noauth_local_webserver
- Go to website displayed by running script and there press Allow
- Page will reload and authentication code will be displayed
- Copy given code into running script
- GoogleDrive permission granted