### PR TITLE
Add cfgpath argument

### DIFF
--- a/src/packtPublishingFreeEbook.py
+++ b/src/packtPublishingFreeEbook.py
@@ -316,9 +316,10 @@ if __name__ == '__main__':
                         action="store_true")
     parser.add_argument("--noauth_local_webserver", help="set if you want auth GoogleDrive without local browser",
                         action="store_true")
+    parser.add_argument("-c", "--cfgpath", default=os.getcwd(), help="select folder where config file can be found")
 
     args = parser.parse_args()
-    cfgFilePath = os.path.join(os.getcwd(), "configFile.cfg")
+    cfgFilePath = os.path.join(args.cfgpath, "configFile.cfg")
 
 #try:
     session = PacktPubHttpSession(PacktAccountDataModel(cfgFilePath))

--- a/src/packtPublishingFreeEbook.py
+++ b/src/packtPublishingFreeEbook.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from bs4 import BeautifulSoup
 
 from utils import *
-logger = log_manager.get_logger(__name__)
+logger={}
 # downgrading logging level for requests
 logging.getLogger("requests").setLevel(logging.WARNING)
 
@@ -320,6 +320,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     cfgFilePath = os.path.join(args.cfgpath, "configFile.cfg")
+    logger = log_manager.get_logger(__name__, args.cfgpath)
 
 #try:
     session = PacktPubHttpSession(PacktAccountDataModel(cfgFilePath))

--- a/src/utils/googleDrive.py
+++ b/src/utils/googleDrive.py
@@ -52,7 +52,7 @@ class GoogleDriveManager():
         the OAuth2 flow is completed to obtain the new credentials.
         Returns: the obtained credentials.
         '''
-        home_dir = os.getcwd()
+        home_dir = self.cfg_file_path
         credential_dir = os.path.join(home_dir, '.credentials')
         if not os.path.exists(credential_dir):
             os.makedirs(credential_dir)

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -4,12 +4,13 @@ import logging
 import os
 import sys
 
-LOG_FILE_PATH = os.path.join(os.getcwd(), "LOG_FILE.log")
-def get_logger(module_name):
+def get_logger(module_name,cfgFilePath=os.getcwd()):
     """ 
         module_name just to distinguish where the logs come from
     """
+    LOG_FILE_PATH = os.path.join(cfgFilePath, "LOG_FILE.log")
     # adding a new logging level
+
     logging.SUCCESS = 19   # as ALL = 0, DEBUG = 10, INFO = 20, WARN = 30, ERROR = 40, FATAL = CRITICAL, CRITICAL = 50
     logging.addLevelName(logging.SUCCESS, 'SUCCESS')
     logger = logging.getLogger(module_name)


### PR DESCRIPTION
I'm running this in a docker container and need the configuration path to be outside of the working folder for the script.
I've added an argument to optionally provide a path.  If not provided it continues to default to getcwd()
Docker container is at https://hub.docker.com/r/biwhite/packt/