### PR TITLE
send_email: Remove connect

### DIFF
--- a/src/utils/mail.py
+++ b/src/utils/mail.py
@@ -48,7 +48,6 @@ class MailBook:
     def _send_email(self, msg):
         try:
             smtp = smtplib.SMTP(host=self._smtp_host, port=self._smtp_port)
-            smtp.connect(host=self._smtp_host, port=self._smtp_port)
             smtp.ehlo()
             smtp.starttls()
             smtp.ehlo()


### PR DESCRIPTION
In my Python 2.7 installation, connecting to GMX SMTP, connect() blocks the connection. It connects directly with "SMTP(host, port)" and doesn't need connect command.

Gmail doesn't need this too (at least in my test).