### PR TITLE
Pass configFile.cfg path as path to file (nor directory)

### DIFF
--- a/src/packtPublishingFreeEbook.py
+++ b/src/packtPublishingFreeEbook.py
@@ -334,7 +334,12 @@ if __name__ == '__main__':
                         action="store_true")
 
     args = parser.parse_args()
-    cfg_file_path = os.path.join(args.cfgpath, "configFile.cfg")
+    if os.path.isdir(args.cfgpath):
+        cfg_file_path = os.path.join(args.cfgpath, "configFile.cfg")
+        logger.warning("The path to the configuration file should point to the file. " +
+                       "Support for directory paths is outdated.")
+    else:
+        cfg_file_path = args.cfgpath
     into_folder = args.folder
 
     try:


### PR DESCRIPTION
Dziwne jest obecne rozwiązanie, gdzie ścieżka do pliku konfiguracyjnego jest podawana w postaci ścieżki do katalogu, gdzie ten plik się znajduje. Proponuje to zmienić. Zmiana powinna być jednak wstecznie kompatybilna, choć z warningiem.