### PR TITLE
Use configparser from six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-requests
-beautifulsoup4==4.5.1
-future
-wheel==0.24.0
-configparser
+apiclient==1.0.3
+beautifulsoup4==4.6.0
+future==0.16.0
+httplib2==0.10.3
+oauth2client==4.1.2
+requests==2.18.4
+six==1.10.0

--- a/src/packtPublishingFreeEbook.py
+++ b/src/packtPublishingFreeEbook.py
@@ -2,16 +2,17 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import argparse
+from collections import OrderedDict
 import datetime as dt
 import logging
 import os
 import re
 import sys
 import time
-from collections import OrderedDict
-import configparser
-import requests
+
 from bs4 import BeautifulSoup
+import requests
+from six.moves import configparser
 
 from utils.anticaptcha import Anticaptcha, AnticaptchaException
 from utils.logger import get_logger
@@ -88,7 +89,7 @@ class PacktPublishingFreeEbook(object):
     """Contains some methods to claim, download or send a free daily ebook"""
 
     download_formats = ('pdf', 'mobi', 'epub', 'code')
-    session = None   
+    session = None
 
     def __init__(self, cfg):
         self.cfg = cfg

--- a/src/utils/google_drive.py
+++ b/src/utils/google_drive.py
@@ -1,6 +1,3 @@
-
-import argparse
-import configparser
 import io
 import logging
 import os
@@ -11,6 +8,7 @@ from apiclient.http import MediaFileUpload, MediaIoBaseDownload
 import httplib2
 from oauth2client import client, tools
 from oauth2client.file import Storage
+from six.moves import configparser
 
 from .logger import get_logger
 

--- a/src/utils/mail.py
+++ b/src/utils/mail.py
@@ -1,11 +1,12 @@
-import os
-import configparser
-import smtplib
-from os.path import basename
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import COMMASPACE, formatdate
+import os
+from os.path import basename
+import smtplib
+
+from six.moves import configparser
 
 from .logger import get_logger
 


### PR DESCRIPTION
There is no need to install `configparser` as dependency, we can use `six` to retrieve it from standard library in both Python 2 and 3.