### PR TITLE
[PREVIEW] Fix Python 3.2 Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+before_install: "if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install 'virtualenv<14.0.0'; fi"
 install: "pip install -r requirements.txt"
 script: pylama


### PR DESCRIPTION
Install virtualenv pre 14.0.0 in Python 3.2 Travis Ci build, as support for this Python version was dropped in virtualenv 14.0.0

For more info see: https://virtualenv.pypa.io/en/latest/changes/