### PR TITLE
Allow to retry after transient errors

### DIFF
--- a/src/grabEbookFromPacktTask.sh
+++ b/src/grabEbookFromPacktTask.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+function log {
+	echo  $(date +"%Y%m%d_%H%M%S") : $@
+}
+
+typeset -i sleepTime=120
+
+typeset -i i=0
+until [  $i -gt 10 ]; do
+ log grab book 
+ cd /home/pi/Packt/src && /usr/bin/python3 packtPublishingFreeEbook.py -g
+ return=$?
+ log returned code [$return]
+ if [ $return -eq 0 ] ; then 
+	break;
+ fi 
+ 
+ log loop until captcha works.
+ log Wait $sleepTime seconds before next retry [$i]
+ sleep $sleepTime 
+ i+=1
+done


### PR DESCRIPTION
Sometime antiCaptcha API Return a transient error [ERROR_NO_SLOT_AVAILABLE] message [No idle workers are available at the moment, please try a bit later or try increasing your maximum bid.]
Add a loop to try again 10 seconds later. 
Also add a shell script for launching with cron on a raspberry Pi.