### PR TITLE
anticaptcha: increase timeout

### DIFF
--- a/src/utils/anticaptcha.py
+++ b/src/utils/anticaptcha.py
@@ -17,7 +17,7 @@ class Anticaptcha(object):
     api_url = 'https://api.anti-captcha.com'
     create_task_url = api_url + '/createTask'
     get_task_result_url = api_url + '/getTaskResult'
-    timeout_time_sec = 60  # timeout
+    timeout_time_sec = 120  # timeout
 
     def __init__(self, api_key):
         self.api_key = api_key


### PR DESCRIPTION
Google increased complexity of its Recaptcha and asks to solve more
puzzles, thus increasing average solve time.

![](https://i.imgur.com/uWUPZz9.png)

