### PR TITLE
Remove Python 3.2 test in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: python
 python:
   - "2.7"
-  # Python 3.2 pylama test fails as doesn't support u"someunicodestring" format.
-  # See https://github.com/gitpython-developers/GitPython/issues/477
-  # Skip Python 3.2.
-  # - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
+  # Python 3.2 pylama test fails as doesn't support u"someunicodestring" format.
+  # See https://github.com/gitpython-developers/GitPython/issues/477
+  # Skip Python 3.2.
+  # - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 install: "pip install -r requirements.txt"
 script: pylama
+


### PR DESCRIPTION
Travis CI tests fail in a Python 3.2 virtualenv - see https://travis-ci.org/eugenesia/Packt-Publishing-Free-Learning/jobs/298054217

The test fails as Python 3.2 doesn't support the Unicode literal `u"myunicodestring"` syntax. See failed Travis job log below. The `u"myunicodestring"` syntax only works on Python 2.7, and Python 3.3 and above.

```bash
  File "/home/travis/virtualenv/python3.2.6/lib/python3.2/site-packages/snowballstemmer/danish_stemmer.py", line 15
    Among(u"hed", -1, 1),
               ^
SyntaxError: invalid syntax
```

GitPython developers have commented that Python 3.2 is so old that it shouldn't be used for testing anyway: https://github.com/gitpython-developers/GitPython/issues/477#issuecomment-252986842

Hence we fix this by removing the requirement to test on Python 3.2. Tests on subsequent Python 3.x versions remain.