### PR TITLE
Drop support for Python 3.3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 install: "pip install -r requirements.txt"
 script: pylama
-


### PR DESCRIPTION
According to [release page](https://www.python.org/download/releases/3.3.0/) Python 3.3.x has reached end of life, therefore it can be removed from list of Python version script is "tested" on.